### PR TITLE
Verbose setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,18 +11,21 @@ Documentation on the usage of ROLLO is hosted at: https://gwenchee.github.io/rol
 `python -m pip install rollo`
 
 ## Running ROLLO 
-`python -m rollo -i <input file> -c <checkpoint file>`
+`python -m rollo -i <input file> -c <checkpoint file> -v `
 
 Command line flags: 
 | Flag | Description | Mandatory ? |
 | ----------- | ----------- | ----------- |
 | -i | name of input file | Yes |
 | -c| name of checkpoint file | No |
+| -v| verbrose output (only include the flag) | No |
 
 The checkpoint file holds the results from the ROLLO simulation and also acts 
 as a restart file. Thus, if a ROLLO simulation ends prematurely, the checkpoint 
 file can be used to restart the code from the most recent population and 
 continue the simulation.
+
+The verbrose flag (-v) enables ROLLO to output extra information for the user. 
 
 ## To build documentation 
 `cd docs` 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Command line flags:
 | ----------- | ----------- | ----------- |
 | -i | name of input file | Yes |
 | -c| name of checkpoint file | No |
-| -v| verbrose output (only include the flag) | No |
+| -v| verbose output (only include the flag) | No |
 
 The checkpoint file holds the results from the ROLLO simulation and also acts 
 as a restart file. Thus, if a ROLLO simulation ends prematurely, the checkpoint 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ as a restart file. Thus, if a ROLLO simulation ends prematurely, the checkpoint
 file can be used to restart the code from the most recent population and 
 continue the simulation.
 
-The verbrose flag (-v) enables ROLLO to output extra information for the user. 
+The verbose flag (-v) enables ROLLO to output extra information for the user. 
 
 ## To build documentation 
 `cd docs` 

--- a/rollo/__main__.py
+++ b/rollo/__main__.py
@@ -5,22 +5,27 @@ import getopt
 
 def main():
     argv = sys.argv[1:]
-    msg = "python rollo -i <inputfile> -c <checkpoint file> "
+    msg = "python rollo -i <inputfile> -c <checkpoint file> -v "
     try:
-        opts, args = getopt.getopt(argv, "i:c:")
+        opts, args = getopt.getopt(argv, "i:c:v")
+        if len(opts) == 0:
+            raise Exception("To run rollo: " + msg)
         opts_dict = {}
         for opt, arg in opts:
             opts_dict[opt] = arg
-        if "-i" in opts_dict:
-            if "-c" in opts_dict:
-                new_run = executor.Executor(
-                    input_file=opts_dict["-i"], checkpoint_file=opts_dict["-c"]
-                )
-            else:
-                new_run = executor.Executor(input_file=opts_dict["-i"])
-            new_run.execute()
-        if len(opts) == 0:
-            raise Exception("To run rollo: " + msg)
+        if "-c" in opts_dict:
+            cp_file = opts_dict['-c']
+        else:
+            cp_file = None
+        if "-v" in opts_dict:
+            verbrose = True
+        else:
+            verbrose = False
+        new_run = executor.Executor(
+            input_file=opts_dict['-i'],
+            checkpoint_file=cp_file,
+            verbrose=verbrose)
+        new_run.execute()
     except getopt.GetoptError:
         raise Exception("To run rollo: " + msg)
 

--- a/rollo/__main__.py
+++ b/rollo/__main__.py
@@ -18,7 +18,7 @@ def main():
         else:
             cp_file = None
         if "-v" in opts_dict:
-            verbrose = True
+            verbose = True
         else:
             verbrose = False
         new_run = executor.Executor(

--- a/rollo/__main__.py
+++ b/rollo/__main__.py
@@ -20,7 +20,7 @@ def main():
         if "-v" in opts_dict:
             verbose = True
         else:
-            verbrose = False
+            verbose = False
         new_run = executor.Executor(
             input_file=opts_dict['-i'],
             checkpoint_file=cp_file,

--- a/rollo/__main__.py
+++ b/rollo/__main__.py
@@ -9,7 +9,7 @@ def main():
     try:
         opts, args = getopt.getopt(argv, "i:c:v")
         if len(opts) == 0:
-            raise Exception("To run rollo: " + msg)
+            raise Exception("To run ROLLO: " + msg)
         opts_dict = {}
         for opt, arg in opts:
             opts_dict[opt] = arg

--- a/rollo/algorithm.py
+++ b/rollo/algorithm.py
@@ -1,7 +1,8 @@
 from .backend import BackEnd
 import random
-import warnings
 import sys
+import logging
+import time
 
 
 class Algorithm(object):
@@ -90,8 +91,9 @@ class Algorithm(object):
                 pool = multiprocessing.Pool()
                 self.toolbox.register("map", pool.map)
             except BaseException:
-                warnings.warn(
-                    "multiprocessing_on_dill failed to import, rollo will run serially."
+                logging.warning(
+                    " multiprocessing_on_dill failed to import, rollo will" +
+                    " run serially. parallel method = none"
                 )
                 pass
         if self.cp_file:
@@ -134,9 +136,19 @@ class Algorithm(object):
         invalids = [ind for ind in pop if not ind.fitness.valid]
         copy_invalids = [self.toolbox.clone(ind) for ind in invalids]
         if self.parallel_method == "job_control":
+            logging.warning(" parallel method = job_control")
             fitnesses = self.toolbox.evaluate(pop)
         else:
+            logging.warning(" parallel method = none")
+            start_time = time.time()
             fitnesses = list(self.toolbox.map(self.toolbox.evaluate, pop))
+            end_time = time.time()
+            logging.info(" Generation: " +
+                         str(0) +
+                         ", Evaluation Total Runtime: " +
+                         str(round(end_time -
+                                   start_time, 2)) +
+                         " seconds")
         # assign fitness values to individuals
         for ind, fitness in zip(pop, fitnesses):
             fitness_vals = []
@@ -177,10 +189,18 @@ class Algorithm(object):
         if self.parallel_method == "job_control":
             fitnesses = self.toolbox.evaluate(list(invalids))
         else:
+            start_time = time.time()
             fitnesses = list(
                 self.toolbox.map(
                     self.toolbox.evaluate,
                     list(invalids)))
+            end_time = time.time()
+            logging.info(" Generation: " +
+                         str(gen) +
+                         ", Evaluation Total Runtime: " +
+                         str(round(end_time -
+                                   start_time, 2)) +
+                         " seconds")
         # assign fitness values to individuals
         for ind, fitness in zip(invalids, fitnesses):
             fitness_vals = []

--- a/rollo/constraints.py
+++ b/rollo/constraints.py
@@ -1,5 +1,5 @@
 import operator
-import warnings
+import logging
 import random
 
 
@@ -126,7 +126,8 @@ class Constraints(object):
         final_pop = [self.toolbox.clone(ind) for ind in new_pop]
         while len(final_pop) < len(pop):
             final_pop.append(self.toolbox.clone(random.choice(new_pop)))
-        warnings.warn(
+        logging.warning(
+            " " +
             str(len(pop) - len(new_pop)) +
             " out of " +
             str(len(pop)) +

--- a/rollo/evaluation.py
+++ b/rollo/evaluation.py
@@ -7,6 +7,7 @@ import jinja2
 from collections import OrderedDict
 from rollo.openmc_evaluation import OpenMCEvaluation
 from rollo.moltres_evaluation import MoltresEvaluation
+import logging
 
 
 class Evaluation:
@@ -120,6 +121,7 @@ class Evaluation:
                     evaluators ordered by output_dict
 
                 """
+                start_time = time.time()
                 order_of_solvers = self.solver_order(input_evaluators)
                 control_vars_dict = {}
                 output_vals_dict = OrderedDict()
@@ -153,6 +155,13 @@ class Evaluation:
                             path = solver + "_" + \
                                 str(ind.gen) + "_" + str(ind.num)
                             shutil.rmtree(path)
+                end_time = time.time()
+                logging.info(" Generation: " +
+                             str(pop[0].gen) +
+                             ", Evaluation Total Runtime: " +
+                             str(round(end_time -
+                                       start_time, 2)) +
+                             " seconds")
                 return all_output_vals  # list of tuples
         else:
             def eval_function(ind):
@@ -186,7 +195,7 @@ class Evaluation:
                     # run execute if they exist
                     if "execute" in input_evaluators[solver]:
                         self.run_execute_serial(
-                            input_evaluators[solver]["execute"], path)
+                            input_evaluators[solver]["execute"], path, solver)
                     # get output values
                     output_vals = self.run_output_script_serial(
                         output_vals, solver, output_dict, control_vars, path
@@ -199,7 +208,6 @@ class Evaluation:
                         if ind.gen < gens - 1:
                             shutil.rmtree(path)
                 return tuple(output_vals)
-
         return eval_function
 
     def create_input_execute_output_scripts(
@@ -276,7 +284,11 @@ class Evaluation:
             solver=solver,
             single_command=self.input_scripts[solver][0] + " " +
             self.input_scripts[solver][1] + " > input_script_out.txt 2>&1")
+        start_time = time.time()
         subprocess.call(run_input, shell=True)
+        end_time = time.time()
+        logging.info(" Solver: " + solver + ", Input Script Runtime: " +
+                     str(round(end_time - start_time, 2)) + " seconds")
         # run execute script if exists
         if "execute" in input_evaluators_solver:
             for i, executable in enumerate(input_evaluators_solver["execute"]):
@@ -288,14 +300,28 @@ class Evaluation:
                     pop=pop,
                     solver=solver,
                     single_command=single_command)
+                start_time = time.time()
                 subprocess.call(execute_input, shell=True)
+                end_time = time.time()
+                logging.info(" Solver: " +
+                             solver +
+                             ", Execute " +
+                             str(i) +
+                             " Runtime: " +
+                             str(round(end_time -
+                                       start_time, 2)) +
+                             " seconds")
         # run output script
         run_output = self.generate_run_command_job_control(
             pop=pop,
             solver=solver,
             single_command=self.output_scripts[solver][0] + " " +
             self.output_scripts[solver][1] + " > output_script_out.txt 2>&1")
+        start_time = time.time()
         subprocess.call(run_output, shell=True)
+        end_time = time.time()
+        logging.info(" Solver: " + solver + ", Output Script Runtime: " +
+                     str(round(end_time - start_time, 2)) + " seconds")
         return
 
     def generate_run_command_job_control(self, pop, solver, single_command):
@@ -416,7 +442,7 @@ class Evaluation:
             self.input_scripts[solver][1])
         return
 
-    def run_execute_serial(self, input_evaluator_solver_execute, path):
+    def run_execute_serial(self, input_evaluator_solver_execute, path, solver):
         """copies execute scripts into an individual's directory if the scripts
         exists then runs it or only the executable for parallel_method=none
         or multiprocessing
@@ -428,6 +454,8 @@ class Evaluation:
             from input file
         path : str
             path name
+        solver : str
+            name of solver
 
         Returns
         -------
@@ -442,6 +470,7 @@ class Evaluation:
                 execute = executables[0]
             self.subprocess_call(
                 path, "execute_" + str(i) + "_output.txt", execute)
+            end_time = time.time()
         return
 
     def solver_order(self, input_evaluators):

--- a/rollo/evaluation.py
+++ b/rollo/evaluation.py
@@ -307,7 +307,7 @@ class Evaluation:
                 end_time = time.time()
                 logging.info(" Solver: " +
                              solver +
-                             ", Execute " +
+                             ", Execute Task " +
                              str(execute_index) +
                              " Runtime: " +
                              str(round(end_time -

--- a/rollo/evaluation.py
+++ b/rollo/evaluation.py
@@ -291,11 +291,13 @@ class Evaluation:
                      str(round(end_time - start_time, 2)) + " seconds")
         # run execute script if exists
         if "execute" in input_evaluators_solver:
-            for i, executable in enumerate(input_evaluators_solver["execute"]):
+            for execute_index, executable in enumerate(
+                    input_evaluators_solver["execute"]):
                 single_command = ""
                 for exe in executable:
                     single_command += exe + " "
-                single_command += "> execute_" + str(i) + "_out.txt 2>&1"
+                single_command += "> execute_" + \
+                    str(execute_index) + "_out.txt 2>&1"
                 execute_input = self.generate_run_command_job_control(
                     pop=pop,
                     solver=solver,
@@ -306,7 +308,7 @@ class Evaluation:
                 logging.info(" Solver: " +
                              solver +
                              ", Execute " +
-                             str(i) +
+                             str(execute_index) +
                              " Runtime: " +
                              str(round(end_time -
                                        start_time, 2)) +

--- a/rollo/executor.py
+++ b/rollo/executor.py
@@ -8,6 +8,7 @@ import json
 import time
 from collections import OrderedDict
 import logging
+import sys
 
 
 class Executor(object):
@@ -43,8 +44,11 @@ class Executor(object):
     def __init__(self, input_file, checkpoint_file=None, verbrose=False):
         self.input_file = input_file
         self.checkpoint_file = checkpoint_file
+        root = logging.getLogger()
+        handler = logging.StreamHandler(sys.stdout)
         if verbrose:
-            logging.basicConfig(level=logging.INFO)
+            handler.setLevel(logging.INFO)
+        root.addHandler(handler)
 
     def execute(self):
         """Executes rollo simulation to generate reactor designs. \n

--- a/rollo/executor.py
+++ b/rollo/executor.py
@@ -44,7 +44,7 @@ class Executor(object):
     def __init__(self, input_file, checkpoint_file=None, verbose=False):
         self.input_file = input_file
         self.checkpoint_file = checkpoint_file
-        if verbrose:
+        if verbose:
             logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
     def execute(self):

--- a/rollo/executor.py
+++ b/rollo/executor.py
@@ -44,12 +44,8 @@ class Executor(object):
     def __init__(self, input_file, checkpoint_file=None, verbrose=False):
         self.input_file = input_file
         self.checkpoint_file = checkpoint_file
-        root = logging.getLogger()
-        handler = logging.StreamHandler(sys.stdout)
         if verbrose:
-            handler.setLevel(logging.INFO)
-            root.setLevel(level=logging.INFO)
-        root.addHandler(handler)
+            logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
     def execute(self):
         """Executes rollo simulation to generate reactor designs. \n

--- a/rollo/executor.py
+++ b/rollo/executor.py
@@ -41,7 +41,7 @@ class Executor(object):
 
     """
 
-    def __init__(self, input_file, checkpoint_file=None, verbrose=False):
+    def __init__(self, input_file, checkpoint_file=None, verbose=False):
         self.input_file = input_file
         self.checkpoint_file = checkpoint_file
         if verbrose:

--- a/rollo/executor.py
+++ b/rollo/executor.py
@@ -36,12 +36,14 @@ class Executor(object):
         Name of input file
     checkpoint_file : str
         Name of checkpoint file
+    verbrose : bool
 
     """
 
-    def __init__(self, input_file, checkpoint_file=None):
+    def __init__(self, input_file, checkpoint_file=None, verbrose=False):
         self.input_file = input_file
         self.checkpoint_file = checkpoint_file
+        self.verbrose = verbrose
 
     def execute(self):
         """Executes rollo simulation to generate reactor designs. \n

--- a/rollo/executor.py
+++ b/rollo/executor.py
@@ -7,7 +7,7 @@ from rollo.toolbox_generator import ToolboxGenerator
 import json
 import time
 from collections import OrderedDict
-import warnings
+import logging
 
 
 class Executor(object):
@@ -43,7 +43,8 @@ class Executor(object):
     def __init__(self, input_file, checkpoint_file=None, verbrose=False):
         self.input_file = input_file
         self.checkpoint_file = checkpoint_file
-        self.verbrose = verbrose
+        if verbrose:
+            logging.basicConfig(level=logging.INFO)
 
     def execute(self):
         """Executes rollo simulation to generate reactor designs. \n
@@ -191,7 +192,7 @@ class Executor(object):
                 output_script = solver_dict["output_script"]
             except BaseException:
                 output_script = None
-                warnings.warn("No output script defined for " + solver)
+                logging.warning(" No output script defined for " + solver)
             evaluator.add_evaluator(
                 solver_name=solver,
                 input_script=solver_dict["input_script"],

--- a/rollo/executor.py
+++ b/rollo/executor.py
@@ -37,7 +37,7 @@ class Executor(object):
         Name of input file
     checkpoint_file : str
         Name of checkpoint file
-    verbrose : bool
+    verbose : bool
 
     """
 

--- a/rollo/executor.py
+++ b/rollo/executor.py
@@ -48,6 +48,7 @@ class Executor(object):
         handler = logging.StreamHandler(sys.stdout)
         if verbrose:
             handler.setLevel(logging.INFO)
+            root.setLevel(level=logging.INFO)
         root.addHandler(handler)
 
     def execute(self):

--- a/rollo/executor.py
+++ b/rollo/executor.py
@@ -93,7 +93,8 @@ class Executor(object):
         )
         alg.generate()
         t1 = time.time()
-        print("Total time in simulation " + str(t1 - t0) + " seconds")
+        print("Total time in simulation " +
+              str(round(t1 - t0, 2)) + " seconds")
         return
 
     def read_input_file(self):

--- a/rollo/input_validation.py
+++ b/rollo/input_validation.py
@@ -1,5 +1,6 @@
 from jsonschema import validate
 from rollo.special_variables import SpecialVariables
+import logging
 
 
 class InputValidation:
@@ -98,6 +99,11 @@ class InputValidation:
             a = input_dict[variable]
         except KeyError:
             input_dict[variable] = default_val
+            logging.warning(
+                " ROLLO added default for variable: " +
+                str(variable) +
+                ", default value = " +
+                str(default_val))
         return input_dict
 
     def validate(self):

--- a/tests/integration_tests/input_test_files/input_test_ackley_job_control.json
+++ b/tests/integration_tests/input_test_files/input_test_ackley_job_control.json
@@ -18,8 +18,8 @@
         "objective": ["min"],
         "weight": [1.0],
         "optimized_variable": ["ackley"],
-        "pop_size": 4,
-        "generations": 2,
+        "pop_size": 100,
+        "generations": 10,
         "parallel": "job_control"
     }
 }

--- a/tests/integration_tests/input_test_files/input_test_ackley_job_control.json
+++ b/tests/integration_tests/input_test_files/input_test_ackley_job_control.json
@@ -18,8 +18,8 @@
         "objective": ["min"],
         "weight": [1.0],
         "optimized_variable": ["ackley"],
-        "pop_size": 100,
-        "generations": 10,
+        "pop_size": 4,
+        "generations": 2,
         "parallel": "job_control"
     }
 }

--- a/tests/unit_tests/test_evaluation.py
+++ b/tests/unit_tests/test_evaluation.py
@@ -345,7 +345,7 @@ def test_run_execute_serial():
     os.mkdir(path)
     ev = Evaluation()
     ev.run_execute_serial([["python", "input_test_run_execute.py"], [
-        "rollo-non-existent-executable"]], path)
+        "rollo-non-existent-executable"]], path, "openmc")
     with open("./" + path + "/execute_0_output.txt") as fp:
         Lines = fp.readlines()[0]
     assert Lines == "[5, 6]\n"


### PR DESCRIPTION
In this PR, I used python's logging package to add logging to ROLLO. The user enables this by adding a `-v` flag:
`python -m rollo -i <input file> -c <checkpoint file> -v `

I also addressed #33 and #9 by adding warnings loggings. The WARNING logs will appear without `-v` flag. The INFO logs will only appear with `-v` flag. 

An example ROLLO output looks like this: 
```
WARNING:root: ROLLO added default for variable: mutation_probability, default value = 0.23
WARNING:root: ROLLO added default for variable: mating_probability, default value = 0.47
WARNING:root: ROLLO added default for variable: mutation_operator, default value = {'operator': 'mutPolynomialBounded', 'eta': 0.23, 'indpb': 0.23}
WARNING:root: ROLLO added default for variable: mating_operator, default value = {'operator': 'cxBlend', 'alpha': 0.46}
Entering generation 0...
WARNING:root: parallel method = job_control
INFO:root: Solver: openmc, Input Script Runtime: 21.1 seconds
INFO:root: Solver: openmc, Execute 0 Runtime: 13.73 seconds
INFO:root: Solver: openmc, Output Script Runtime: 21.23 seconds
INFO:root: Generation: 0, Evaluation Total Runtime: 56.13 seconds
WARNING:root: 3 out of 4 inds were constrained
                                                              oup                                                           ind
                        ------------------------------------------------------------------------------- --------------------------------------------
time    gen     evals   avg                     std     min                     max                     avg             min             max
56.1503 0       4       [6.75119225 1.29395975] [0. 0.] [6.75119225 1.29395975] [6.75119225 1.29395975] [6.75119225]    [6.75119225]    [6.75119225]
Entering generation 1...
INFO:root: Solver: openmc, Input Script Runtime: 20.27 seconds
INFO:root: Solver: openmc, Execute 0 Runtime: 12.46 seconds
INFO:root: Solver: openmc, Output Script Runtime: 20.23 seconds
INFO:root: Generation: 1, Evaluation Total Runtime: 53.01 seconds
WARNING:root: 0 out of 4 inds were constrained
                                                              oup                                                           ind
                        ------------------------------------------------------------------------------- --------------------------------------------
time    gen     evals   avg                     std     min                     max                     avg             min             max
56.1503 0       4       [6.75119225 1.29395975] [0. 0.] [6.75119225 1.29395975] [6.75119225 1.29395975] [6.75119225]    [6.75119225]    [6.75119225]
109.16  1       3       [6.75119225 1.29395975] [0. 0.] [6.75119225 1.29395975] [6.75119225 1.29395975] [6.75119225]    [6.75119225]    [6.75119225]
rollo Simulation Completed!
Total time in simulation 109.16 seconds
```